### PR TITLE
Minor patch 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .cover
+test.go

--- a/Makefile
+++ b/Makefile
@@ -49,15 +49,15 @@ install-golangcilint:
 
 test:
 	@echo "Testing..."
-	@$(GO) test -cover -race ./...
+	@$(GO) test -cover -race ./pkg
 
 bench:
 	@echo "Benching..."
-	@$(GO) test -bench=. ./...
+	@$(GO) test -bench=. ./pkg
 
 race:
 	@echo "Racing..."
-	@$(GO) test -v -race ./...
+	@$(GO) test -v -race ./pkg
 
 cover:
 	@echo "Show coverage"

--- a/pkg/command.go
+++ b/pkg/command.go
@@ -32,8 +32,13 @@ func (c Command) Expression() *regexp.Regexp {
 	expr := c.Text()
 
 	for _, param := range c.Parameters() {
-		expr = strings.Replace(expr, "<"+param.Name()+":"+param.Datatype()+">", "("+param.Expression().String()+")", -1)
-		expr = strings.Replace(expr, "<"+param.Name()+">", "("+param.Expression().String()+")", -1)
+		newString := "(" + param.Expression().String() + ")"
+
+		oldString1 := "<" + param.Name() + ":" + param.Datatype() + ">"
+		expr = strings.Replace(expr, oldString1, newString, -1)
+
+		oldString2 := "<" + param.Name() + ">"
+		expr = strings.Replace(expr, oldString2, newString, -1)
 	}
 
 	return regexp.MustCompile("^" + expr + "$")

--- a/pkg/command.go
+++ b/pkg/command.go
@@ -32,7 +32,7 @@ func (c Command) Expression() *regexp.Regexp {
 	expr := c.Text()
 
 	for _, param := range c.Parameters() {
-		newString := "(" + param.Expression().String() + ")"
+		newString := param.Expression().String()
 
 		oldString1 := "<" + param.Name() + ":" + param.Datatype() + ">"
 		expr = strings.Replace(expr, oldString1, newString, -1)
@@ -41,7 +41,7 @@ func (c Command) Expression() *regexp.Regexp {
 		expr = strings.Replace(expr, oldString2, newString, -1)
 	}
 
-	return regexp.MustCompile("^" + expr + "$")
+	return regexp.MustCompile("^" + strings.ReplaceAll(expr, " ", "\\s?") + "$")
 }
 
 // Parameters returns the list of defined parameters
@@ -84,6 +84,9 @@ func (c Command) Position(param ParameterInterface) int {
 
 // Match returns the parameter matching the expression at the defined position
 func (c Command) Match(req string) (MatchInterface, error) {
+	space := regexp.MustCompile(`\s+`)
+	req = space.ReplaceAllString(req, " ")
+
 	if c.Matches(req) {
 		return Match{c, req}, nil
 	}

--- a/pkg/command_test.go
+++ b/pkg/command_test.go
@@ -24,7 +24,8 @@ func TestMatches(t *testing.T) {
 	}{
 		{"command", "example", false},
 		{"command", "command", true},
-		{"command", "command example", false},
+		{"command        ", "command", true},
+		{"command", "command         example", false},
 		{"command <lorem>", "command", false},
 		{"command <lorem>", "command example", true},
 		{"command <lorem>", "command 1234567", true},
@@ -33,6 +34,11 @@ func TestMatches(t *testing.T) {
 		{"command <lorem:integer>", "command example", false},
 		{"command <lorem:integer>", "command 1234567", true},
 		{"command <lorem>", "command command command", false},
+		{"command <ipsum:integer?>", "command", true},
+		{"command <ipsum:integer?>", "command 2", true},
+		{"command <lorem:string?>", "command", true},
+		{"command <lorem:string> <ipsum:string?>", "command 1234567", true},
+		{"command <lorem:string> <ipsum:string?>", "command 1234567 test", true},
 	}
 
 	for _, set := range data {

--- a/pkg/match.go
+++ b/pkg/match.go
@@ -40,7 +40,7 @@ func (m Match) Integer(name string) (int, error) {
 func (m Match) Parameter(param ParameterInterface) (string, error) {
 	pos := m.Command.Position(param)
 	if pos == -1 {
-		return "", errors.New("Unknonw parameter \"" + param.Name() + "\"")
+		return "", errors.New("Unknown parameter \"" + param.Name() + "\"")
 	}
 
 	matches := m.Command.Expression().FindAllStringSubmatch(m.Request, -1)[0][1:]

--- a/pkg/match_test.go
+++ b/pkg/match_test.go
@@ -13,6 +13,7 @@ func TestMatch(t *testing.T) {
 		{"revert from <project:string> last <commits:integer> commits", "revert from example last 51 commits", 1, "51"},
 		{"revert from <project:string> last <commits:integer> commits on (stage|prod)", "revert from example last 51 commits on stage", 2, "stage"},
 		{"revert from <project:string> last <commits:integer> commits on (stage|prod)", "revert from example last 51 commits on prod", 2, "prod"},
+		{"revert from <project:string?> last <commits:integer> commits", "revert from last 51 commits", 1, "51"},
 	}
 
 	for _, set := range data {
@@ -41,6 +42,7 @@ func TestMatchAndInteger(t *testing.T) {
 		parameter string
 		value     int
 	}{
+		{"command <param1:integer?> <param2:integer>", "command 1234", "param2", 1234},
 		{"command <param1:integer>", "command 1234", "param1", 1234},
 		{"revert from <project:string> last <commits:integer> commits", "revert from example last 51 commits", "commits", 51},
 	}

--- a/pkg/parameter.go
+++ b/pkg/parameter.go
@@ -6,12 +6,14 @@ import (
 )
 
 var regexpMapping = map[string]string{
-	"string":  "[^\\s]+",
-	"integer": "[0-9]+",
+	"string":   "([^\\s]+)",
+	"string?":  "([^\\s]+)?",
+	"integer":  "([0-9]+)",
+	"integer?": "([0-9]+)?",
 }
 
-// Expression returns the regexp for a data type
-func Expression(datatype string) *regexp.Regexp {
+// GetRegexpExpression returns the regexp for a data type
+func GetRegexpExpression(datatype string) *regexp.Regexp {
 	if exp, ok := regexpMapping[datatype]; ok {
 		return regexp.MustCompile(exp)
 	}
@@ -56,7 +58,7 @@ func (p Parameter) Equals(param ParameterInterface) bool {
 
 // NewParameterWithType returns
 func NewParameterWithType(name string, datatype string) Parameter {
-	return Parameter{name, datatype, Expression(datatype)}
+	return Parameter{name, datatype, GetRegexpExpression(datatype)}
 }
 
 // Parse parses parameter info

--- a/pkg/parameter_test.go
+++ b/pkg/parameter_test.go
@@ -10,8 +10,8 @@ func TestExpression(t *testing.T) {
 		data       string
 		expression string
 	}{
-		{"string", "[^\\s]+"},
-		{"integer", "[0-9]+"},
+		{"string", "([^\\s]+)"},
+		{"integer", "([0-9]+)"},
 		{"unknown", ""},
 	}
 
@@ -22,7 +22,7 @@ func TestExpression(t *testing.T) {
 			t.Errorf("TextExpression regexp does not compile: %s", set.expression)
 		}
 
-		test := Expression(set.data)
+		test := GetRegexpExpression(set.data)
 
 		if test == nil && set.expression != "" {
 			t.Errorf("Expression for data \"%s\" is not valid", set.data)
@@ -40,8 +40,8 @@ func TestParameterExpression(t *testing.T) {
 		data       string
 		expression string
 	}{
-		{"lorem", "string", "[^\\s]+"},
-		{"ipsum", "integer", "[0-9]+"},
+		{"lorem", "string", "([^\\s]+)"},
+		{"ipsum", "integer", "([0-9]+)"},
 	}
 
 	for _, set := range data {


### PR DESCRIPTION
command.go Expression refactor
Adds support for optional string and integer
Trims extra whitespace to one whitespace in command

fixes #2 
fixes #3 