### PR TITLE
feat: :hammer: Converts defined options to parameterized defined options

### DIFF
--- a/pkg/command.go
+++ b/pkg/command.go
@@ -48,15 +48,15 @@ func (c Command) Expression() *regexp.Regexp {
 // Parameters returns the list of defined parameters
 func (c Command) Parameters() []Parameter {
 	var list []Parameter
-	re := regexp.MustCompile(definedParameterPattern)
+	re := regexp.MustCompile(paramterPattern)
 	result := re.FindAllStringSubmatch(c.Text(), -1)
 
-	for _, p := range result {
+	for listIndex, p := range result {
 		if len(p) != 2 {
 			continue
 		}
 
-		list = append(list, Parse(p[1]))
+		list = append(list, Parse(p[0], listIndex))
 	}
 
 	return list

--- a/pkg/command_test.go
+++ b/pkg/command_test.go
@@ -134,11 +134,11 @@ func TestTokenize(t *testing.T) {
 		command string
 		tokens  []*Token
 	}{
-		{"command <lorem>", []*Token{NewTokenWithType("command", notParameter), NewTokenWithType("lorem", definedParameter)}},
-		{"cmd <lorem:string>", []*Token{NewTokenWithType("cmd", notParameter), NewTokenWithType("lorem:string", definedParameter)}},
-		{"cmd <lorem:string?>", []*Token{NewTokenWithType("cmd", notParameter), NewTokenWithType("lorem:string?", optionalParameter)}},
-		{"cmd <lorem:integer?>", []*Token{NewTokenWithType("cmd", notParameter), NewTokenWithType("lorem:integer?", optionalParameter)}},
-		{"cmd <lorem:?>", []*Token{NewTokenWithType("cmd", notParameter), NewTokenWithType("lorem:?", optionalParameter)}},
+		{"command <lorem>", []*Token{NewTokenWithType("command", notParameter, 0), NewTokenWithType("lorem", definedParameter, 1)}},
+		{"cmd <lorem:string>", []*Token{NewTokenWithType("cmd", notParameter, 0), NewTokenWithType("lorem:string", definedParameter, 1)}},
+		{"cmd <lorem:string?>", []*Token{NewTokenWithType("cmd", notParameter, 0), NewTokenWithType("lorem:string?", optionalParameter, 1)}},
+		{"cmd <lorem:integer?>", []*Token{NewTokenWithType("cmd", notParameter, 0), NewTokenWithType("lorem:integer?", optionalParameter, 1)}},
+		{"cmd <lorem:?>", []*Token{NewTokenWithType("cmd", notParameter, 0), NewTokenWithType("lorem:?", optionalParameter, 1)}},
 	}
 	var cmd Command
 	for _, set := range data {
@@ -150,11 +150,11 @@ func TestTokenize(t *testing.T) {
 
 		tokens := cmd.Tokenize()
 		for index, token := range set.tokens {
-			if tokens[index].Word != token.Word {
-				t.Errorf("\"%s\" missing token \"%s\"", cmd.Text(), token.Word)
+			if tokens[index].Word() != token.Word() {
+				t.Errorf("\"%s\" missing token \"%s\"", cmd.Text(), token.Word())
 			}
-			if tokens[index].Type != token.Type {
-				t.Errorf("for input: %s & test case: %s, %d token type mismatch %d", tokens[index].Word, token.Word, tokens[index].Type, token.Type)
+			if tokens[index].Type() != token.Type() {
+				t.Errorf("for input: %s & test case: %s, %d token type mismatch %d", tokens[index].Word(), token.Word(), tokens[index].Type(), token.Type())
 			}
 		}
 	}

--- a/pkg/match_test.go
+++ b/pkg/match_test.go
@@ -11,6 +11,9 @@ func TestMatch(t *testing.T) {
 	}{
 		{"command <param1:integer>", "command 1234", 0, "1234"},
 		{"command <param1:remaining_string>", "command lorem ipsum", 0, "lorem ipsum"},
+		{"(comm|Comm) <param1:string> <param2:integer>", "comm hello 2", 0, "comm"},
+		{"(comm|Comm) <param1:string> <param2:integer>", "comm hello 2", 1, "hello"},
+		{"(comm|Comm) <param1:string> <param2:integer>", "comm hello 2", 2, "2"},
 		{"revert from <project:string> last <commits:integer> commits", "revert from example last 51 commits", 1, "51"},
 		{"revert from <project:string> last <commits:integer> commits on (stage|prod)", "revert from example last 51 commits on stage", 2, "stage"},
 		{"revert from <project:string> last <commits:integer> commits on (stage|prod)", "revert from example last 51 commits on prod", 2, "prod"},
@@ -85,6 +88,10 @@ func TestMatchAndString(t *testing.T) {
 		{"deploy <project:string> to (stage|prod)", "deploy klaus to stage", "project", "klaus"},
 		{"deploy <project:string> to (stage|prod)+", "deploy klaus to prod", "project", "klaus"},
 		{"deploy <project:string> to (stage|prod)*", "deploy klaus to ", "project", "klaus"},
+		{"deploy to (stage|prod) at <host>", "deploy to stage at localhost", "option0", "stage"},
+		{"deploy to (stage|prod) at <host>", "deploy to prod at localhost", "option0", "prod"},
+		{"deploy to (stage|prod) at <host>", "deploy to prod at localhost", "host", "localhost"},
+		{"deploy to (stage|prod) at (localhost|server)", "deploy to prod at server", "option1", "server"},
 	}
 
 	for _, set := range data {

--- a/pkg/parameter_test.go
+++ b/pkg/parameter_test.go
@@ -58,17 +58,18 @@ func TestParameterExpression(t *testing.T) {
 
 func TestParse(t *testing.T) {
 	var data = []struct {
-		text     string
-		name     string
-		datatype string
+		text             string
+		name             string
+		datatype         string
+		paramterPosition int
 	}{
-		{"<lorem>", "lorem", "string"},
-		{"<ipsum:integer>", "ipsum", "integer"},
+		{"<lorem>", "lorem", "string", 0},
+		{"<ipsum:integer>", "ipsum", "integer", 0},
 	}
 
 	var param Parameter
 	for _, set := range data {
-		param = Parse(set.text)
+		param = Parse(set.text, set.paramterPosition)
 
 		if param.Name() != set.name {
 			t.Errorf("param.Name() should be \"%s\", but is \"%s\"", set.name, param.Name())

--- a/pkg/token.go
+++ b/pkg/token.go
@@ -2,7 +2,6 @@ package allot
 
 import (
 	"errors"
-	"fmt"
 	"regexp"
 	"strings"
 )
@@ -11,6 +10,8 @@ const (
 	definedOptionsPattern    = "\\(.*?\\)"
 	definedParameterPattern  = "<(.*?)>"
 	optionalParameterPattern = "<(.*?)[?]>"
+	paramterPattern          = definedParameterPattern + "|" + definedOptionsPattern
+	numberPattern            = "\\d+"
 )
 
 const (
@@ -22,21 +23,37 @@ const (
 
 // Token represents the Token object
 type Token struct {
-	Word string
-	Type int
+	word     string
+	tType    int
+	position int
+}
+
+// Word returns the token word
+func (t Token) Word() string {
+	return t.word
+}
+
+// Type returns the token word
+func (t Token) Type() int {
+	return t.tType
+}
+
+// Position returns the token word
+func (t Token) Position() int {
+	return t.position
 }
 
 func (t Token) IsParameter() bool {
-	return t.Type != notParameter
+	return t.tType != notParameter
 }
 
 // GetParameterFromToken return the parameter object created from token
 func (t Token) GetParameterFromToken() (Parameter, error) {
 	if t.IsParameter() {
-		return Parse(t.Word), nil
+		return Parse(t.Word(), t.Position()), nil
 	}
 
-	return Parameter{}, errors.New(t.Word + " is not a parameter")
+	return Parameter{}, errors.New(t.Word() + " is not a parameter")
 }
 
 // tokenize returns array of the Tokens present in the command
@@ -48,22 +65,21 @@ func tokenize(line string) []*Token {
 	tokens := make([]*Token, len(words))
 	for i, word := range words {
 		tWord := word[1 : len(word)-1]
-		fmt.Println(word, definedParameterRegex.MatchString(word))
 		switch {
 		case optionalParameterRegex.MatchString(word):
-			tokens[i] = NewTokenWithType(tWord, optionalParameter)
+			tokens[i] = NewTokenWithType(tWord, optionalParameter, i)
 		case definedParameterRegex.MatchString(word):
-			tokens[i] = NewTokenWithType(tWord, definedParameter)
+			tokens[i] = NewTokenWithType(tWord, definedParameter, i)
 		case definedOptionsRegex.MatchString(word):
-			tokens[i] = NewTokenWithType(tWord, definedOptionsParameter)
+			tokens[i] = NewTokenWithType(tWord, definedOptionsParameter, i)
 		default:
-			tokens[i] = NewTokenWithType(word, notParameter)
+			tokens[i] = NewTokenWithType(word, notParameter, i)
 		}
 	}
 	return tokens
 }
 
 // NewTokenWithType returns a Token
-func NewTokenWithType(word string, tType int) *Token {
-	return &Token{word, tType}
+func NewTokenWithType(word string, tType int, tokenPosition int) *Token {
+	return &Token{word, tType, tokenPosition}
 }

--- a/pkg/token_test.go
+++ b/pkg/token_test.go
@@ -9,19 +9,19 @@ func TestGetParameterFromToken(t *testing.T) {
 		token     *Token
 		parameter Parameter
 	}{
-		{NewTokenWithType("cmd", notParameter), NewParameterWithType("cmd", "")},
-		{NewTokenWithType("lorem", definedParameter), NewParameterWithType("lorem", "string")},
-		{NewTokenWithType("lorem:string", definedParameter), NewParameterWithType("lorem", "string")},
-		{NewTokenWithType("lorem:string?", optionalParameter), NewParameterWithType("lorem", "string?")},
-		{NewTokenWithType("lorem:integer?", optionalParameter), NewParameterWithType("lorem", "integer?")},
-		{NewTokenWithType("lorem:?", optionalParameter), NewParameterWithType("lorem", "string?")},
+		{NewTokenWithType("cmd", notParameter, 0), NewParameterWithType("cmd", "")},
+		{NewTokenWithType("lorem", definedParameter, 0), NewParameterWithType("lorem", "string")},
+		{NewTokenWithType("lorem:string", definedParameter, 0), NewParameterWithType("lorem", "string")},
+		{NewTokenWithType("lorem:string?", optionalParameter, 0), NewParameterWithType("lorem", "string?")},
+		{NewTokenWithType("lorem:integer?", optionalParameter, 0), NewParameterWithType("lorem", "integer?")},
+		{NewTokenWithType("lorem:?", optionalParameter, 0), NewParameterWithType("lorem", "string?")},
 	}
 	for _, set := range data {
 		param, err := set.token.GetParameterFromToken()
-		if err != nil && set.token.Type != notParameter {
-			t.Errorf("Cannot parse token: %s into parameter: %s", set.token.Word, set.parameter.name)
-		} else if err == nil && param.datatype != set.parameter.datatype {
-			t.Errorf("Expected parsed token type to be: %s but got: %s", set.parameter.datatype, param.datatype)
+		if err != nil && set.token.Type() != notParameter {
+			t.Errorf("Cannot parse token: %s into parameter: %s", set.token.Word(), set.parameter.Name())
+		} else if err == nil && param.Datatype() != set.parameter.Datatype() {
+			t.Errorf("Expected parsed token type to be: %s but got: %s", set.parameter.Datatype(), param.Datatype())
 		}
 	}
 }


### PR DESCRIPTION
Now options will be treated as parameterized tokens, so that they can be accessed with a parameter name composed of "option" and the parameter position.
for example

Expression: "deploy app in `(stage|prod)` at `(localhost|server)`"
String: "deploy app in stage at server"

The parameters and their values in the above mentioned command will be
 - option0 -> stage
 - option1 -> server.

fixes #11 
